### PR TITLE
Add check for colnames in kNN()

### DIFF
--- a/R/kNN.R
+++ b/R/kNN.R
@@ -115,6 +115,10 @@ kNN <- function(data, variable=colnames(data), metric=NULL, k=5, dist_var=colnam
                 imp_var=TRUE,imp_suffix="imp", addRF=FALSE, onlyRF=FALSE,addRandom=FALSE,useImputedDist=TRUE,weightDist=FALSE) {
   check_data(data)
   data_df <- !is.data.table(data)
+  # check for colnames before forcing variable
+  if (is.null(colnames(data))) { 
+    colnames(data) <- colnames(data, do.NULL = FALSE)
+  }
   force(variable)
   force(dist_var)
   if (data_df) {

--- a/tests/testthat/test_kNN.R
+++ b/tests/testthat/test_kNN.R
@@ -212,3 +212,15 @@ test_that("kNN Tests - randomForest list - StringsAsFactors",{
   expect_equal(sum(dd$y_imp),6)
   
 })
+
+## Test for NULL colnames
+test_that("kNN Test - matrix, data frame and data table with NULL colnames", {
+  ds_matrix <- matrix(c(NA, 2:6), ncol = 3)
+  expect_equal(kNN(ds_matrix, imp_var = FALSE)[1, 1], 2)
+  ds_df <- as.data.frame(ds_matrix)
+  colnames(ds_df) <- NULL # as.data.frame() creates column names
+  expect_equal(kNN(ds_df, imp_var = FALSE)[1, 1], 2)
+  ds_dt <- as.data.table(ds_matrix)
+  colnames(ds_dt) <- NULL
+  expect_equal(as.numeric(kNN(ds_dt, imp_var = FALSE)[1, 1]), 2)
+})


### PR DESCRIPTION
This is an attempt to close #48. 

I first thought, the problem was only related to matrices (as the heading of #48 suggests). However, the real problem are the missing (NULL) column names. You can see this, if you only apply the first commit with the tests. All three added tests will fail. 
A solution is to check for NULL colnames and add them, if necessary (second commit).

Feel free to change this PR to your liking. 