### PR TITLE
Attempt to close #49

### DIFF
--- a/R/regressionImp.R
+++ b/R/regressionImp.R
@@ -60,7 +60,7 @@ regressionImp <- function(formula, data, family = "AUTO", robust = FALSE, imp_va
       if (!inherits(family, "function")) {
         if (family == "AUTO") {
           TFna <- TFna2 & !is.na(lhs_vector)
-          if (inherits(lhs_vector, "numeric")) {
+          if (is.numeric(lhs_vector)) {
             nLev <- 0
             if (robust) {
               fn <- lmrob

--- a/tests/testthat/test_regressionImp.R
+++ b/tests/testthat/test_regressionImp.R
@@ -1,0 +1,12 @@
+test_that("regressionImp works with integer and double columns", {
+  test_df <- data.frame(col_int = c(1L, NA, 3L, 4L, 5L), col_dbl = c(1.1, 2, NA, 4, 5))
+  imp_col_dbl <- regressionImp(col_dbl ~ col_int, test_df)
+  expect_false(anyNA(imp_col_dbl$col_dbl))
+  imp_val_dbl <- imp_col_dbl[3, "col_dbl"]
+  expect_true(2 < imp_val_dbl && imp_val_dbl < 4)
+
+  imp_col_int <- regressionImp(col_int ~ col_dbl, test_df)
+  expect_false(anyNA(imp_col_int$col_int))
+  imp_val_int <- imp_col_int[2, "col_int"]
+  expect_true(1 < imp_val_int && imp_val_int < 3)
+})


### PR DESCRIPTION
It is safer to check for numeric columns via `is.numeric()` instead of using `inherits()` (see for example bottom part of https://stackoverflow.com/a/27923346). 

I checked the example from #49. Locally, everything worked fine. I did not add the airquality dataset to the test to prevent adding a new package dependency.

