### PR TITLE
Improve test robutness

### DIFF
--- a/tests/testthat/test_IRMI_ordered.R
+++ b/tests/testthat/test_IRMI_ordered.R
@@ -4,7 +4,8 @@
 ###############################################################################
 test_df = data.frame(ord = ordered(sample(c(letters[1:2], NA), size = 1000, replace = T)), v1 = rnorm(1000), v2 = rnorm(1000), m=rnorm(1000),
                      b=sample(LETTERS[1:2],1000,replace=TRUE),
-                     c=sample(LETTERS[1:5],1000,replace=TRUE),co=rpois(1000,10))
+                     c=sample(LETTERS[1:5],1000,replace=TRUE),co=rpois(1000,10),
+                     stringsAsFactors=FALSE)
 test_df[sample(1000,100),"m"] <- 0
 test_that("irmi base",{
   expect_warning(ir <- irmi(test_df, mixed = "m", count="co"))

--- a/tests/testthat/test_graphics.R
+++ b/tests/testthat/test_graphics.R
@@ -16,7 +16,6 @@ test_that("aggr missing failed", {
 })
 
 test_that("aggr imputed failed", {
-  
   sleep_IMPUTED <- kNN(sleep)
   a <- aggr(sleep_IMPUTED, delimiter="_imp")
   summary(a)

--- a/tests/testthat/test_graphics.R
+++ b/tests/testthat/test_graphics.R
@@ -7,6 +7,8 @@ data(chorizonDL, package = "VIM")
 data(kola.background, package = "VIM")
 data(tao, package = "VIM")
 test_that("aggr missing failed", {
+  # switch to a tempdir() to ensure writeability
+  withr::local_dir(withr::local_tempdir())
   a <- aggr(sleep, numbers=TRUE)
   summary(a)
   print(a)
@@ -14,6 +16,7 @@ test_that("aggr missing failed", {
 })
 
 test_that("aggr imputed failed", {
+  
   sleep_IMPUTED <- kNN(sleep)
   a <- aggr(sleep_IMPUTED, delimiter="_imp")
   summary(a)


### PR DESCRIPTION
Currently, the plot.aggr() call tries to create a file Rplots.pdf which may not be writeable in the test execution directory; adding the switch to tempdir() increases the robustness of the writeability assumption.

Next, the tests in `tests/testthat/test_IRMI_ordered.R` assume that `stringsAsFactors=FALSE`, but as VIM only depends on R >= 3.5.0, that won't always by correct. Supplying this argument explicitly removes the cross-version ambiguity to `stringsAsFactors`' value.